### PR TITLE
Ensure files are added to each compilation chunk

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,9 @@ WebpackRTLPlugin.prototype.apply = function(compiler) {
       var rtlFiles = [],
           cssnanoPromise = Promise.resolve()
 
-      chunk.files.forEach(function(asset) {
+      chunk.files.forEach((asset) => {
         if (path.extname(asset) === '.css') {
-          const baseSource = source.source()
+          const baseSource = compilation.assets[asset].source()
           let rtlSource = rtlcss.process(baseSource, this.options.options)
           let filename
 


### PR DESCRIPTION
This fixes the plugin so that `compilation.getStats()` returns the added `.rtl.css` files as well.
This is necessary for things like `HtmlWebpackPlugin` to function properly