### PR TITLE
Minify original css

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,10 +45,17 @@ WebpackRTLPlugin.prototype.apply = function(compiler) {
             }
 
             cssnanoPromise = cssnanoPromise.then(() => {
-              return cssnano.process(rtlSource, nanoOptions).then(output => {
+
+              const rtlMinify = cssnano.process(rtlSource, nanoOptions).then(output => {
                 compilation.assets[filename] = new ConcatSource(output.css)
                 rtlFiles.push(filename)
               });
+
+              const originalMinify = cssnano.process( baseSource, nanoOptions).then(output => {
+                compilation.assets[asset] = new ConcatSource(output.css)
+              });
+
+              return Promise.all([rtlMinify,originalMinify]);
             })
           }
           else {


### PR DESCRIPTION
That is done so we would be able not to minify original css
at the loaders stage, so `/*rtl:ignore*/` won't be stripped
Later, after RTL css is created, we should minify the
original chunk.

So to fix the issue described in #3:
1. Upgrade to Webpack2 so UglifyJS plugin won't cause [everything to be minified](https://github.com/webpack/webpack/issues/283)
2. Don't use `minimized` on css loader
3. Let `webpack-rtl-plugin` take care of the minification
