### PR TITLE
fix(filename-path): maintain same path when no filename option is passed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,8 @@ WebpackRTLPlugin.prototype.apply = function(compiler) {
             }
           }
           else {
-            filename = `${path.basename(asset, '.css')}.rtl.css`
+            const newFilename = `${path.basename(asset, '.css')}.rtl`
+            filename = asset.replace(path.basename(asset, '.css'), newFilename)
           }
 
           if (this.options.diffOnly) {

--- a/test/index.js
+++ b/test/index.js
@@ -130,6 +130,46 @@ describe('Webpack RTL Plugin', () => {
     })
   })
 
+  describe('Same path when no filename option', () => {
+    let cssBundlePath
+    let rtlCssBundlePath
+    let cssPath = 'assets/css'
+
+    before(done => {
+      const config = {
+        ...baseConfig,
+        output: {
+          path: path.resolve(__dirname, 'dist-path'),
+          filename: 'bundle.js',
+        },
+        plugins: [
+          new ExtractTextPlugin(path.join(cssPath, 'style.css')),
+          new WebpackRTLPlugin(),
+        ],
+      }
+
+      webpack(config, (err, stats) => {
+        if (err) {
+          return done(err)
+        }
+
+        if (stats.hasErrors()) {
+          return done(new Error(stats.toString()))
+        }
+
+        cssBundlePath = path.join(__dirname, 'dist-path', cssPath, 'style.css')
+        rtlCssBundlePath = path.join(__dirname, 'dist-path', cssPath, 'style.rtl.css')
+
+        done()
+      })
+    })
+
+    it('should create two css bundles with same path', () => {
+      expect(fs.existsSync(cssBundlePath)).to.be.true
+      expect(fs.existsSync(rtlCssBundlePath)).to.be.true
+    })
+  })
+
   describe('Rtlcss options', () => {
     const rtlCssBundlePath = path.join(__dirname, 'dist-options/style.rtl.css')
 


### PR DESCRIPTION
when passing a path with the *ExtractTextPlugin*, the path of the extracted `.css` gets ignored
example:
```
plugins: [
  new ExtractTextPlugin('assets/css/style.css'),
  new WebpackRTLPlugin()
]
```
output will be
```
assets/css/style.css
style.rtl.css
```

this addresses the issue resulting in
```
assets/css/style.css
assets/css/style.rtl.css
```

tests are passing, and added test for new additions