### PR TITLE
Test and filename options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-lib
 test/dist*
 node_modules
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ new WebpackRTLPlugin({
 })
 ```
 
+* `test` a RegExp (object or string) that must match asset filename
 * `filename` the filename of the result file. May contain patterns in brackets. Default to `style.css`.
   * `[contenthash]` a hash of the content of the extracted file
   * `[id]` the module identifier

--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ new WebpackRTLPlugin({
 })
 ```
 
-* `filename` the filename of the result file. May contain `[contenthash]`. Default to `style.css`.
+* `filename` the filename of the result file. May contain patterns in brackets. Default to `style.css`.
   * `[contenthash]` a hash of the content of the extracted file
+  * `[id]` the module identifier
+  * `[name]` the module name
+  * `[file]` the extracted file filename 
+  * `[filebase]` the extracted file basename
+  * `[ext]` the extracted file extension
+  * May be an array of replace function arguments like `[/(\.css)/i, '-rtl$1']`.
+    Replace applies to filename that specified in extract-text-webpack-plugin.
 * `options` Options given to `rtlcss`. See the [rtlcss documentation for available options](http://rtlcss.com/learn/usage-guide/options/).
 * `plugins` RTLCSS plugins given to `rtlcss`. See the [rtlcss documentation for writing plugins](http://rtlcss.com/learn/extending-rtlcss/writing-a-plugin/). Default to `[]`.
 * `diffOnly` If set to `true`, the stylesheet created will only contain the css that differs from the source stylesheet. Default to `false`.

--- a/dist/index.js
+++ b/dist/index.js
@@ -46,14 +46,29 @@ WebpackRTLPlugin.prototype.apply = function (compiler) {
           var rtlSource = _rtlcss2.default.process(baseSource, _this.options.options, _this.options.plugins);
           var filename = void 0;
 
-          console.log('asset name:', asset, _this.options.filename);
-
-          if (_this.options.filename) {
+          if (_this.options.filename instanceof Array && _this.options.filename.length === 2) {
+            filename = asset.replace(_this.options.filename[0], _this.options.filename[1]);
+          } else if (_this.options.filename) {
             filename = _this.options.filename;
 
             if (/\[contenthash]/.test(_this.options.filename)) {
               var hash = (0, _crypto.createHash)('md5').update(rtlSource).digest('hex').substr(0, 10);
               filename = filename.replace('[contenthash]', hash);
+            }
+            if (/\[id]/.test(_this.options.filename)) {
+              filename = filename.replace('[id]', chunk.id);
+            }
+            if (/\[name]/.test(_this.options.filename)) {
+              filename = filename.replace('[name]', chunk.name);
+            }
+            if (/\[file]/.test(_this.options.filename)) {
+              filename = filename.replace('[file]', asset);
+            }
+            if (/\[filebase]/.test(_this.options.filename)) {
+              filename = filename.replace('[filebase]', _path2.default.basename(asset));
+            }
+            if (/\[ext]/.test(_this.options.filename)) {
+              filename = filename.replace('.[ext]', _path2.default.extname(asset));
             }
           } else {
             var newFilename = _path2.default.basename(asset, '.css') + '.rtl';

--- a/dist/index.js
+++ b/dist/index.js
@@ -41,47 +41,51 @@ WebpackRTLPlugin.prototype.apply = function (compiler) {
       var cssnanoPromise = Promise.resolve();
 
       chunk.files.forEach(function (asset) {
-        var match = _this.options.test ? new RegExp(_this.options.test).test(asset) : _path2.default.extname(asset) === '.css';
+        var match = _this.options.test ? new RegExp(_this.options.test).test(asset) : true;
 
-        if (!match) {
+        if (_path2.default.extname(asset) !== '.css') {
           return;
         }
 
         var baseSource = compilation.assets[asset].source();
-        var rtlSource = _rtlcss2.default.process(baseSource, _this.options.options, _this.options.plugins);
         var filename = void 0;
+        var rtlSource = void 0;
 
-        if (_this.options.filename instanceof Array && _this.options.filename.length === 2) {
-          filename = asset.replace(_this.options.filename[0], _this.options.filename[1]);
-        } else if (_this.options.filename) {
-          filename = _this.options.filename;
+        if (match) {
+          rtlSource = _rtlcss2.default.process(baseSource, _this.options.options, _this.options.plugins);
 
-          if (/\[contenthash]/.test(_this.options.filename)) {
-            var hash = (0, _crypto.createHash)('md5').update(rtlSource).digest('hex').substr(0, 10);
-            filename = filename.replace('[contenthash]', hash);
-          }
-          if (/\[id]/.test(_this.options.filename)) {
-            filename = filename.replace('[id]', chunk.id);
-          }
-          if (/\[name]/.test(_this.options.filename)) {
-            filename = filename.replace('[name]', chunk.name);
-          }
-          if (/\[file]/.test(_this.options.filename)) {
-            filename = filename.replace('[file]', asset);
-          }
-          if (/\[filebase]/.test(_this.options.filename)) {
-            filename = filename.replace('[filebase]', _path2.default.basename(asset));
-          }
-          if (/\[ext]/.test(_this.options.filename)) {
-            filename = filename.replace('.[ext]', _path2.default.extname(asset));
-          }
-        } else {
-          var newFilename = _path2.default.basename(asset, '.css') + '.rtl';
-          filename = asset.replace(_path2.default.basename(asset, '.css'), newFilename);
-        }
+          if (_this.options.filename instanceof Array && _this.options.filename.length === 2) {
+            filename = asset.replace(_this.options.filename[0], _this.options.filename[1]);
+          } else if (_this.options.filename) {
+            filename = _this.options.filename;
 
-        if (_this.options.diffOnly) {
-          rtlSource = (0, _cssDiff2.default)(baseSource, rtlSource);
+            if (/\[contenthash]/.test(_this.options.filename)) {
+              var hash = (0, _crypto.createHash)('md5').update(rtlSource).digest('hex').substr(0, 10);
+              filename = filename.replace('[contenthash]', hash);
+            }
+            if (/\[id]/.test(_this.options.filename)) {
+              filename = filename.replace('[id]', chunk.id);
+            }
+            if (/\[name]/.test(_this.options.filename)) {
+              filename = filename.replace('[name]', chunk.name);
+            }
+            if (/\[file]/.test(_this.options.filename)) {
+              filename = filename.replace('[file]', asset);
+            }
+            if (/\[filebase]/.test(_this.options.filename)) {
+              filename = filename.replace('[filebase]', _path2.default.basename(asset));
+            }
+            if (/\[ext]/.test(_this.options.filename)) {
+              filename = filename.replace('.[ext]', _path2.default.extname(asset));
+            }
+          } else {
+            var newFilename = _path2.default.basename(asset, '.css') + '.rtl';
+            filename = asset.replace(_path2.default.basename(asset, '.css'), newFilename);
+          }
+
+          if (_this.options.diffOnly) {
+            rtlSource = (0, _cssDiff2.default)(baseSource, rtlSource);
+          }
         }
 
         if (_this.options.minify !== false) {
@@ -91,19 +95,22 @@ WebpackRTLPlugin.prototype.apply = function (compiler) {
           }
 
           cssnanoPromise = cssnanoPromise.then(function () {
-
-            var rtlMinify = _cssnano2.default.process(rtlSource, nanoOptions).then(function (output) {
-              compilation.assets[filename] = new _webpackSources.ConcatSource(output.css);
-              rtlFiles.push(filename);
-            });
-
-            var originalMinify = _cssnano2.default.process(baseSource, nanoOptions).then(function (output) {
+            var minify = _cssnano2.default.process(baseSource, nanoOptions).then(function (output) {
               compilation.assets[asset] = new _webpackSources.ConcatSource(output.css);
             });
 
-            return Promise.all([rtlMinify, originalMinify]);
+            if (match) {
+              var rtlMinify = _cssnano2.default.process(rtlSource, nanoOptions).then(function (output) {
+                compilation.assets[filename] = new _webpackSources.ConcatSource(output.css);
+                rtlFiles.push(filename);
+              });
+
+              minify = Promise.all([minify, rtlMinify]);
+            }
+
+            return minify;
           });
-        } else {
+        } else if (match) {
           compilation.assets[filename] = new _webpackSources.ConcatSource(rtlSource);
           rtlFiles.push(filename);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,101 @@
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+var _crypto = require('crypto');
+
+var _rtlcss = require('rtlcss');
+
+var _rtlcss2 = _interopRequireDefault(_rtlcss);
+
+var _webpackSources = require('webpack-sources');
+
+var _cssDiff = require('@romainberger/css-diff');
+
+var _cssDiff2 = _interopRequireDefault(_cssDiff);
+
+var _async = require('async');
+
+var _cssnano = require('cssnano');
+
+var _cssnano2 = _interopRequireDefault(_cssnano);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var WebpackRTLPlugin = function WebpackRTLPlugin() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { filename: false, options: {}, plugins: [] };
+
+  this.options = options;
+};
+
+WebpackRTLPlugin.prototype.apply = function (compiler) {
+  var _this = this;
+
+  compiler.plugin('emit', function (compilation, callback) {
+    (0, _async.forEachOfLimit)(compilation.chunks, 5, function (chunk, key, cb) {
+      var rtlFiles = [],
+          cssnanoPromise = Promise.resolve();
+
+      chunk.files.forEach(function (asset) {
+        if (_path2.default.extname(asset) === '.css') {
+          var baseSource = compilation.assets[asset].source();
+          var rtlSource = _rtlcss2.default.process(baseSource, _this.options.options, _this.options.plugins);
+          var filename = void 0;
+
+          console.log('asset name:', asset, _this.options.filename);
+
+          if (_this.options.filename) {
+            filename = _this.options.filename;
+
+            if (/\[contenthash]/.test(_this.options.filename)) {
+              var hash = (0, _crypto.createHash)('md5').update(rtlSource).digest('hex').substr(0, 10);
+              filename = filename.replace('[contenthash]', hash);
+            }
+          } else {
+            var newFilename = _path2.default.basename(asset, '.css') + '.rtl';
+            filename = asset.replace(_path2.default.basename(asset, '.css'), newFilename);
+          }
+
+          if (_this.options.diffOnly) {
+            rtlSource = (0, _cssDiff2.default)(baseSource, rtlSource);
+          }
+
+          if (_this.options.minify !== false) {
+            var nanoOptions = {};
+            if (_typeof(_this.options.minify) === 'object') {
+              nanoOptions = _this.options.minify;
+            }
+
+            cssnanoPromise = cssnanoPromise.then(function () {
+
+              var rtlMinify = _cssnano2.default.process(rtlSource, nanoOptions).then(function (output) {
+                compilation.assets[filename] = new _webpackSources.ConcatSource(output.css);
+                rtlFiles.push(filename);
+              });
+
+              var originalMinify = _cssnano2.default.process(baseSource, nanoOptions).then(function (output) {
+                compilation.assets[asset] = new _webpackSources.ConcatSource(output.css);
+              });
+
+              return Promise.all([rtlMinify, originalMinify]);
+            });
+          } else {
+            compilation.assets[filename] = new _webpackSources.ConcatSource(rtlSource);
+            rtlFiles.push(filename);
+          }
+        }
+      });
+
+      cssnanoPromise.then(function () {
+        chunk.files.push.apply(chunk.files, rtlFiles);
+        cb();
+      });
+    }, callback);
+  });
+};
+
+module.exports = WebpackRTLPlugin;

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "webpack-rtl-plugin",
   "version": "1.6.0",
   "description": "Webpack plugin to produce a rtl css bundle",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "clean": "rm -rf test/dist*",
-    "build": "rm -rf lib && babel src --out-dir lib",
+    "build": "rm -rf dist && babel src --out-dir dist",
     "test": "npm run clean && npm run build && mocha --compilers js:babel-register test/*.js",
     "prepublish": "npm run build"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -16,50 +16,54 @@ WebpackRTLPlugin.prototype.apply = function(compiler) {
       const rtlFiles = []
       let cssnanoPromise = Promise.resolve()
 
-      chunk.files.forEach((asset) => {
-        const match = this.options.test ? new RegExp(this.options.test).test(asset) : path.extname(asset) === '.css';
+      chunk.files.forEach(asset => {
+        const match = this.options.test ? new RegExp(this.options.test).test(asset) : true
 
-        if (!match) {
-          return;
+        if (path.extname(asset) !== '.css') {
+          return
         }
 
         const baseSource = compilation.assets[asset].source()
-        let rtlSource = rtlcss.process(baseSource, this.options.options, this.options.plugins)
         let filename
+        let rtlSource
 
-        if (this.options.filename instanceof Array && this.options.filename.length === 2) {
-          filename = asset.replace(this.options.filename[0], this.options.filename[1])
-        }
-        else if (this.options.filename) {
-          filename = this.options.filename
+        if (match) {
+          rtlSource = rtlcss.process(baseSource, this.options.options, this.options.plugins)
 
-          if (/\[contenthash]/.test(this.options.filename)) {
-            const hash = createHash('md5').update(rtlSource).digest('hex').substr(0, 10)
-            filename = filename.replace('[contenthash]', hash)
+          if (this.options.filename instanceof Array && this.options.filename.length === 2) {
+            filename = asset.replace(this.options.filename[0], this.options.filename[1])
           }
-          if (/\[id]/.test(this.options.filename)) {
-            filename = filename.replace('[id]', chunk.id)
-          }
-          if (/\[name]/.test(this.options.filename)) {
-            filename = filename.replace('[name]', chunk.name)
-          }
-          if (/\[file]/.test(this.options.filename)) {
-            filename = filename.replace('[file]', asset)
-          }
-          if (/\[filebase]/.test(this.options.filename)) {
-            filename = filename.replace('[filebase]', path.basename(asset))
-          }
-          if (/\[ext]/.test(this.options.filename)) {
-            filename = filename.replace('.[ext]', path.extname(asset))
-          }
-        }
-        else {
-          const newFilename = `${path.basename(asset, '.css')}.rtl`
-          filename = asset.replace(path.basename(asset, '.css'), newFilename)
-        }
+          else if (this.options.filename) {
+            filename = this.options.filename
 
-        if (this.options.diffOnly) {
-          rtlSource = cssDiff(baseSource, rtlSource)
+            if (/\[contenthash]/.test(this.options.filename)) {
+              const hash = createHash('md5').update(rtlSource).digest('hex').substr(0, 10)
+              filename = filename.replace('[contenthash]', hash)
+            }
+            if (/\[id]/.test(this.options.filename)) {
+              filename = filename.replace('[id]', chunk.id)
+            }
+            if (/\[name]/.test(this.options.filename)) {
+              filename = filename.replace('[name]', chunk.name)
+            }
+            if (/\[file]/.test(this.options.filename)) {
+              filename = filename.replace('[file]', asset)
+            }
+            if (/\[filebase]/.test(this.options.filename)) {
+              filename = filename.replace('[filebase]', path.basename(asset))
+            }
+            if (/\[ext]/.test(this.options.filename)) {
+              filename = filename.replace('.[ext]', path.extname(asset))
+            }
+          }
+          else {
+            const newFilename = `${path.basename(asset, '.css')}.rtl`
+            filename = asset.replace(path.basename(asset, '.css'), newFilename)
+          }
+
+          if (this.options.diffOnly) {
+            rtlSource = cssDiff(baseSource, rtlSource)
+          }
         }
 
         if (this.options.minify !== false) {
@@ -69,20 +73,23 @@ WebpackRTLPlugin.prototype.apply = function(compiler) {
           }
 
           cssnanoPromise = cssnanoPromise.then(() => {
-
-            const rtlMinify = cssnano.process(rtlSource, nanoOptions).then(output => {
-              compilation.assets[filename] = new ConcatSource(output.css)
-              rtlFiles.push(filename)
-            });
-
-            const originalMinify = cssnano.process( baseSource, nanoOptions).then(output => {
+            let minify = cssnano.process( baseSource, nanoOptions).then(output => {
               compilation.assets[asset] = new ConcatSource(output.css)
             });
 
-            return Promise.all([rtlMinify,originalMinify]);
+            if (match) {
+              const rtlMinify = cssnano.process(rtlSource, nanoOptions).then(output => {
+                compilation.assets[filename] = new ConcatSource(output.css)
+                rtlFiles.push(filename)
+              });
+
+              minify = Promise.all([minify, rtlMinify]);
+            }
+
+            return minify;
           })
         }
-        else {
+        else if (match) {
           compilation.assets[filename] = new ConcatSource(rtlSource)
           rtlFiles.push(filename)
         }

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,30 @@ WebpackRTLPlugin.prototype.apply = function(compiler) {
           let rtlSource = rtlcss.process(baseSource, this.options.options, this.options.plugins)
           let filename
 
-          if (this.options.filename) {
+          if (this.options.filename instanceof Array && this.options.filename.length === 2) {
+            filename = asset.replace(this.options.filename[0], this.options.filename[1])
+          }
+          else if (this.options.filename) {
             filename = this.options.filename
 
-            if (/\[contenthash\]/.test(this.options.filename)) {
+            if (/\[contenthash]/.test(this.options.filename)) {
               const hash = createHash('md5').update(rtlSource).digest('hex').substr(0, 10)
               filename = filename.replace('[contenthash]', hash)
+            }
+            if (/\[id]/.test(this.options.filename)) {
+              filename = filename.replace('[id]', chunk.id)
+            }
+            if (/\[name]/.test(this.options.filename)) {
+              filename = filename.replace('[name]', chunk.name)
+            }
+            if (/\[file]/.test(this.options.filename)) {
+              filename = filename.replace('[file]', asset)
+            }
+            if (/\[filebase]/.test(this.options.filename)) {
+              filename = filename.replace('[filebase]', path.basename(asset))
+            }
+            if (/\[ext]/.test(this.options.filename)) {
+              filename = filename.replace('.[ext]', path.extname(asset))
             }
           }
           else {

--- a/test/index.js
+++ b/test/index.js
@@ -67,6 +67,55 @@ describe('Webpack RTL Plugin', () => {
     })
   })
 
+  describe('Test option', () => {
+    let bundlePath
+    let cssBundlePath
+    let rtlCssBundlePath
+
+    before(done => {
+      const config = {
+        ...baseConfig,
+        entry: {
+          'js/main.js': path.join(__dirname, 'src/index.js'),
+          'css/style.css': path.join(__dirname, 'src/index.js'),
+        },
+        output: {
+          path: path.resolve(__dirname, 'dist-test'),
+          filename: '[name]',
+        },
+        plugins: [
+          new ExtractTextPlugin('css/style.css'),
+          new WebpackRTLPlugin({
+            test: /css\//i,
+            minify: false,
+          }),
+        ],
+      }
+
+      webpack(config, (err, stats) => {
+        if (err) {
+          return done(err)
+        }
+
+        if (stats.hasErrors()) {
+          return done(new Error(stats.toString()))
+        }
+
+        bundlePath = path.join(__dirname, 'dist-test/js/main.js')
+        cssBundlePath = path.join(__dirname, 'dist-test/css/style.css')
+        rtlCssBundlePath = path.join(__dirname, 'dist-test/css/style.rtl.css')
+
+        done()
+      })
+    })
+
+    it('should create a two css bundles', () => {
+      expect(fs.existsSync(bundlePath)).to.be.true
+      expect(fs.existsSync(cssBundlePath)).to.be.true
+      expect(fs.existsSync(rtlCssBundlePath)).to.be.true
+    })
+  })
+
   describe('Filename options', () => {
     let cssBundleName
     let rtlCssBundleName

--- a/test/index.js
+++ b/test/index.js
@@ -304,8 +304,8 @@ describe('Webpack RTL Plugin', () => {
     })
 
     it('should only contain the diff between the source and the rtl version', () => {
-      const contentRrlCss = fs.readFileSync(rtlCssBundlePath, 'utf-8')
-      const expected = fs.readFileSync(path.join(__dirname, 'rtl-diff-result.css'), 'utf-8')
+      const contentRrlCss = fs.readFileSync(rtlCssBundlePath, 'utf-8').replace(/\r/g, '')
+      const expected = fs.readFileSync(path.join(__dirname, 'rtl-diff-result.css'), 'utf-8').replace(/\r/g, '')
       expect(contentRrlCss).to.equal(expected)
     })
   })


### PR DESCRIPTION
Hi!

Because of needs of project that I'm working on here is some changes for the plugin:

* added ability to filter files for rtlcss processing with "test" option
* added extended control of result rtl filename (a lot of pattern and almighty "replace" functionality)
* (don't know if it actually needed) renamed "lib" folder to "dist" due it's more common way
* (don't know if it actually needed) added built version to the repository

Feel free to contact me with your thoughts and purposals. I'll be happy if those changes gets to new version of the package.