### PR TITLE
Add a suffix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This will create the normal `style.css` and an additionnal `style.rtl.css`.
 ```
 new WebpackRTLPlugin({
   filename: 'style.[contenthash].rtl.css',
+  suffix: false,
   options: {},
   plugins: [],
   diffOnly: false,
@@ -56,6 +57,7 @@ new WebpackRTLPlugin({
 
 * `filename` the filename of the result file. May contain `[contenthash]`. Default to `style.css`.
   * `[contenthash]` a hash of the content of the extracted file
+* `suffix` suffix added to the original base filename before the extension, if filename isn't provided. Default to `.rtl`.
 * `options` Options given to `rtlcss`. See the [rtlcss documentation for available options](http://rtlcss.com/learn/usage-guide/options/).
 * `plugins` RTLCSS plugins given to `rtlcss`. See the [rtlcss documentation for writing plugins](http://rtlcss.com/learn/extending-rtlcss/writing-a-plugin/). Default to `[]`.
 * `diffOnly` If set to `true`, the stylesheet created will only contain the css that differs from the source stylesheet. Default to `false`.

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import cssDiff from '@romainberger/css-diff'
 import {forEachOfLimit} from 'async'
 import cssnano from 'cssnano'
 
-const WebpackRTLPlugin = function(options = {filename: false, options: {}, plugins: []}) {
+const WebpackRTLPlugin = function(options = {filename: false, suffix: false, options: {}, plugins: []}) {
   this.options = options
 }
 
@@ -31,7 +31,9 @@ WebpackRTLPlugin.prototype.apply = function(compiler) {
             }
           }
           else {
-            const newFilename = `${path.basename(asset, '.css')}.rtl`
+          	const suffix = this.options.suffix || '.rtl'
+          	const newFilename = `${path.basename(asset, '.css')}${suffix}`
+
             filename = asset.replace(path.basename(asset, '.css'), newFilename)
           }
 

--- a/test/index.js
+++ b/test/index.js
@@ -170,6 +170,45 @@ describe('Webpack RTL Plugin', () => {
     })
   })
 
+  describe('Suffix option', () => {
+    let rtlCssBundlePath
+    let cssPath = 'assets/css'
+
+    before(done => {
+      const config = {
+        ...baseConfig,
+        output: {
+          path: path.resolve(__dirname, 'dist-path'),
+          filename: 'bundle.js',
+        },
+        plugins: [
+          new ExtractTextPlugin(path.join(cssPath, 'style.css')),
+          new WebpackRTLPlugin({
+            suffix: '-rtl'
+          }),
+        ],
+      }
+
+      webpack(config, (err, stats) => {
+        if (err) {
+          return done(err)
+        }
+
+        if (stats.hasErrors()) {
+          return done(new Error(stats.toString()))
+        }
+
+        rtlCssBundlePath = path.join(__dirname, 'dist-path', cssPath, 'style-rtl.css')
+
+        done()
+      })
+    })
+
+    it('should create rtl css bundle with -rtl suffix', () => {
+      expect(fs.existsSync(rtlCssBundlePath)).to.be.true
+    })
+  })
+
   describe('Rtlcss options', () => {
     const rtlCssBundlePath = path.join(__dirname, 'dist-options/style.rtl.css')
 


### PR DESCRIPTION
By default, this plugin would add `.rtl` to the original filenames.

In various use cases, it might be useful to use other suffixes, like `-rtl` for example.
This change adds a suffix option, to replace the default `.rtl` if set (and if the `filename` option isn't set)
