### PR TITLE
Use compilation.assets to find css files instead of compilation.chunks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,62 +12,55 @@ const WebpackRTLPlugin = function(options = {filename: false, options: {}, plugi
 
 WebpackRTLPlugin.prototype.apply = function(compiler) {
   compiler.plugin('emit', (compilation, callback) => {
-    forEachOfLimit(compilation.chunks, 5, (chunk, key, cb) => {
-      var rtlFiles = [],
-          cssnanoPromise = Promise.resolve()
+    forEachOfLimit(compilation.assets, 5, (asset, key, cb) => {
+      var cssnanoPromise = Promise.resolve()
 
-      chunk.files.forEach((asset) => {
-        if (path.extname(asset) === '.css') {
-          const baseSource = compilation.assets[asset].source()
-          let rtlSource = rtlcss.process(baseSource, this.options.options, this.options.plugins)
-          let filename
+      if (path.extname(key) === '.css') {
+        const baseSource = asset.source()
+        let rtlSource = rtlcss.process(baseSource, this.options.options, this.options.plugins)
+        let filename
 
-          if (this.options.filename) {
-            filename = this.options.filename
+        if (this.options.filename) {
+          filename = this.options.filename
 
-            if (/\[contenthash\]/.test(this.options.filename)) {
-              const hash = createHash('md5').update(rtlSource).digest('hex').substr(0, 10)
-              filename = filename.replace('[contenthash]', hash)
-            }
-          }
-          else {
-            const newFilename = `${path.basename(asset, '.css')}.rtl`
-            filename = asset.replace(path.basename(asset, '.css'), newFilename)
-          }
-
-          if (this.options.diffOnly) {
-            rtlSource = cssDiff(baseSource, rtlSource)
-          }
-
-          if (this.options.minify !== false) {
-            let nanoOptions = {}
-            if (typeof this.options.minify === 'object') {
-              nanoOptions = this.options.minify
-            }
-
-            cssnanoPromise = cssnanoPromise.then(() => {
-
-              const rtlMinify = cssnano.process(rtlSource, nanoOptions).then(output => {
-                compilation.assets[filename] = new ConcatSource(output.css)
-                rtlFiles.push(filename)
-              });
-
-              const originalMinify = cssnano.process( baseSource, nanoOptions).then(output => {
-                compilation.assets[asset] = new ConcatSource(output.css)
-              });
-
-              return Promise.all([rtlMinify,originalMinify]);
-            })
-          }
-          else {
-            compilation.assets[filename] = new ConcatSource(rtlSource)
-            rtlFiles.push(filename)
+          if (/\[contenthash\]/.test(this.options.filename)) {
+            const hash = createHash('md5').update(rtlSource).digest('hex').substr(0, 10)
+            filename = filename.replace('[contenthash]', hash)
           }
         }
-      })
+        else {
+          const newFilename = `${path.basename(key, '.css')}.rtl`
+          filename = key.replace(path.basename(key, '.css'), newFilename)
+        }
+
+        if (this.options.diffOnly) {
+          rtlSource = cssDiff(baseSource, rtlSource)
+        }
+
+        if (this.options.minify !== false) {
+          let nanoOptions = {}
+          if (typeof this.options.minify === 'object') {
+            nanoOptions = this.options.minify
+          }
+
+          cssnanoPromise = cssnanoPromise.then(() => {
+            const rtlMinify = cssnano.process(rtlSource, nanoOptions).then(output => {
+              compilation.assets[filename] = new ConcatSource(output.css)
+            });
+
+            const originalMinify = cssnano.process(baseSource, nanoOptions).then(output => {
+              compilation.assets[key] = new ConcatSource(output.css)
+            });
+
+            return Promise.all([rtlMinify, originalMinify]);
+          })
+        }
+        else {
+          compilation.assets[filename] = new ConcatSource(rtlSource)
+        }
+      }
 
       cssnanoPromise.then(() => {
-        chunk.files.push.apply(chunk.files, rtlFiles)
         cb()
       })
     }, callback)


### PR DESCRIPTION
This PR changes the behaviour of `WebpackRtlPlugin` to use `compilation.assets` for identifying css files instead of `compilation.chunks` in order to work correctly with other plugins such as `AddAssetHtmlPlugin`. Closes #16.