### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const WebpackRTLPlugin = function(options = {filename: false, options: {}, plugi
 }
 
 WebpackRTLPlugin.prototype.apply = function(compiler) {
-  compiler.plugin('emit', (compilation, callback) => {
+  compiler.hooks.emit.tapAsync('WebpackRTLPlugin', (compilation, callback) => {
     forEachOfLimit(compilation.chunks, 5, (chunk, key, cb) => {
       var rtlFiles = [],
           cssnanoPromise = Promise.resolve()


### PR DESCRIPTION
Fixes this warning when you use the plugin with Webpack 4:

```
(node:27844) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```