### PR TITLE
Upgrade cssnano to v4 and bump a few other packages, too

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,9 @@
   },
   "dependencies": {
     "@romainberger/css-diff": "^1.0.3",
-    "async": "^2.0.0-rc.6",
-    "cssnano": "^3.7.1",
-    "postcss": "^5.0.21",
+    "async": "^2.0.0",
+    "cssnano": "^4.1.8",
     "rtlcss": "^2.0.4",
-    "webpack-sources": "^0.1.2"
+    "webpack-sources": "^1.3.0"
   }
 }


### PR DESCRIPTION
This PR upgrades the cssnano dependency from v3 to v4, so that the webpack RTL plugin minifies the CSS output with the latest version of the minifier.

There are a few drive-by package upgrades, with much smaller impact:
- remove the `postcss` dependency as it's not used by the plugin directly. Only transitively via cssnano.
- remove the "RC" version bit from the `async` dependency. Latest version, as of today, is 2.6.1 and it gets installed with both the old and new semver ref.
- bump the `webpack-sources` dependency from 0.1.2 to 1.3.0. The plugin uses only the `ConcatSource` class and a look at its [commit history](https://github.com/webpack/webpack-sources/commits/master/lib/ConcatSource.js) shows that all changes were performance improvements and ES6 modernizations, without any API changes. Should be safe.